### PR TITLE
Fix car player lyric catalog detection

### DIFF
--- a/app/src/main/java/com/zuoqirun/lyricscompanion/MultiSourceLyricClient.java
+++ b/app/src/main/java/com/zuoqirun/lyricscompanion/MultiSourceLyricClient.java
@@ -44,7 +44,7 @@ final class MultiSourceLyricClient {
         List<Future<Result>> futures = new ArrayList<>();
         for (String provider : providers) {
             futures.add(completion.submit(() -> tryProvider(
-                    provider, "netease".equals(provider) ? mediaId : "",
+                    provider, directMediaId(currentSource, provider, mediaId),
                     title, artist, durationMs)));
         }
         long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(FALLBACK_TIMEOUT_MS);
@@ -118,6 +118,11 @@ final class MultiSourceLyricClient {
         if ("netease".equals(source) || "qqmusic".equals(source)
                 || "kugou".equals(source) || "kuwo".equals(source)) return source;
         return "";
+    }
+
+    static String directMediaId(String currentSource, String provider, String mediaId) {
+        return "netease".equals(currentSource) && "netease".equals(provider)
+                ? mediaId : "";
     }
 
     static final class Result {

--- a/app/src/main/java/com/zuoqirun/lyricscompanion/MultiSourceLyricClient.java
+++ b/app/src/main/java/com/zuoqirun/lyricscompanion/MultiSourceLyricClient.java
@@ -35,11 +35,6 @@ final class MultiSourceLyricClient {
         String preferred = providerForSource(currentSource);
         List<String> providers = new ArrayList<>(Arrays.asList(
                 "netease", "qqmusic", "kugou", "kuwo"));
-        List<String> priority = new ArrayList<>();
-        if (!preferred.isEmpty()) priority.add(preferred);
-        for (String provider : providers) {
-            if (!priority.contains(provider)) priority.add(provider);
-        }
         CompletionService<Result> completion = new ExecutorCompletionService<>(fallbackPool);
         List<Future<Result>> futures = new ArrayList<>();
         for (String provider : providers) {
@@ -71,12 +66,7 @@ final class MultiSourceLyricClient {
         } finally {
             for (Future<Result> future : futures) future.cancel(true);
         }
-        for (String provider : priority) {
-            for (Result result : successful) {
-                if (provider.equals(result.providerId)) return result;
-            }
-        }
-        return Result.EMPTY;
+        return chooseResult(preferred, successful);
     }
 
     private Result tryProvider(String provider, String mediaId, String title, String artist,
@@ -123,6 +113,16 @@ final class MultiSourceLyricClient {
     static String directMediaId(String currentSource, String provider, String mediaId) {
         return "netease".equals(currentSource) && "netease".equals(provider)
                 ? mediaId : "";
+    }
+
+    static Result chooseResult(String preferred, List<Result> successful) {
+        if (successful == null || successful.isEmpty()) return Result.EMPTY;
+        if (preferred != null && !preferred.isEmpty()) {
+            for (Result result : successful) {
+                if (preferred.equals(result.providerId)) return result;
+            }
+        }
+        return successful.get(0);
     }
 
     static final class Result {

--- a/app/src/main/java/com/zuoqirun/lyricscompanion/MusicAppRegistry.java
+++ b/app/src/main/java/com/zuoqirun/lyricscompanion/MusicAppRegistry.java
@@ -6,8 +6,13 @@ final class MusicAppRegistry {
     private static final App[] KNOWN_APPS = {
             new App("netease", "网易云音乐", "com.netease.cloudmusic"),
             new App("qqmusic", "QQ 音乐", "com.tencent.qqmusic"),
+            new App("qqmusic", "QQ 音乐", "com.tencent.qqmusiccar"),
             new App("kugou", "酷狗音乐", "com.kugou.android"),
+            new App("kugou", "酷狗音乐", "com.kugou.auto"),
             new App("kuwo", "酷我音乐", "cn.kuwo.player"),
+            new App("kuwo", "酷我音乐", "cn.kuwo.kwmusiccar"),
+            new App("kuwo", "酷我音乐", "cn.kuwo.kwmusic"),
+            new App("kuwo", "酷我音乐", "cn.kuwo.car"),
             new App("spotify", "Spotify", "com.spotify.music"),
             new App("soda", "汽水音乐", "com.luna.music"),
             new App("migu", "咪咕音乐", "cmccwm.mobilemusic"),
@@ -27,14 +32,35 @@ final class MusicAppRegistry {
                     || normalizedPackage.startsWith(app.packagePrefix + ".")) return app;
         }
         String label = safe(applicationLabel).trim();
+        App labelMatch = resolveLabel(label, normalizedPackage);
+        if (labelMatch != null) return labelMatch;
         if (label.isEmpty()) {
             int separator = normalizedPackage.lastIndexOf('.');
             label = separator >= 0 ? normalizedPackage.substring(separator + 1) : normalizedPackage;
         }
-        if (label.isEmpty() || "player".equals(label) || "music".equals(label)) {
+        if (label.isEmpty() || "player".equalsIgnoreCase(label)
+                || "music".equalsIgnoreCase(label)) {
             label = "音乐播放器";
         }
         return new App("media", label, normalizedPackage, false);
+    }
+
+    private static App resolveLabel(String applicationLabel, String packageName) {
+        String label = safe(applicationLabel).toLowerCase(Locale.ROOT)
+                .replace(" ", "").replace("-", "").replace("_", "");
+        if (label.contains("网易云") || label.contains("cloudmusic")) {
+            return new App("netease", "网易云音乐", packageName);
+        }
+        if (label.contains("qq音乐") || label.contains("qqmusic")) {
+            return new App("qqmusic", "QQ 音乐", packageName);
+        }
+        if (label.contains("酷狗") || label.contains("kugou")) {
+            return new App("kugou", "酷狗音乐", packageName);
+        }
+        if (label.contains("酷我") || label.contains("kuwo")) {
+            return new App("kuwo", "酷我音乐", packageName);
+        }
+        return null;
     }
 
     static int selectionScore(int playbackRank, boolean hasMetadata,

--- a/app/src/test/java/com/zuoqirun/lyricscompanion/MusicAppRegistryTest.java
+++ b/app/src/test/java/com/zuoqirun/lyricscompanion/MusicAppRegistryTest.java
@@ -1,0 +1,45 @@
+package com.zuoqirun.lyricscompanion;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class MusicAppRegistryTest {
+    @Test public void recognizesCarEditionPackageNames() {
+        assertSource("qqmusic", "com.tencent.qqmusiccar", "");
+        assertSource("kuwo", "cn.kuwo.kwmusiccar", "");
+        assertSource("kugou", "com.kugou.auto", "");
+    }
+
+    @Test public void recognizesVendorWrappedPlayersByApplicationLabel() {
+        assertSource("netease", "vendor.player.one", "网易云音乐车机版");
+        assertSource("qqmusic", "vendor.player.two", "QQ音乐 HD");
+        assertSource("kugou", "vendor.player.three", "酷狗概念版");
+        assertSource("kuwo", "vendor.player.four", "酷我音乐");
+    }
+
+    @Test public void keepsUnknownPlayersCatalogNeutral() {
+        MusicAppRegistry.App app = MusicAppRegistry.resolve("vendor.player", "车载播放器");
+        assertEquals("media", app.sourceId);
+        assertFalse(app.known);
+    }
+
+    @Test public void onlyTrustsMediaIdFromNetEaseSession() {
+        assertEquals("123456", MultiSourceLyricClient.directMediaId(
+                "netease", "netease", "123456"));
+        assertEquals("", MultiSourceLyricClient.directMediaId(
+                "qqmusic", "netease", "123456"));
+        assertEquals("", MultiSourceLyricClient.directMediaId(
+                "media", "netease", "123456"));
+        assertEquals("", MultiSourceLyricClient.directMediaId(
+                "netease", "qqmusic", "123456"));
+    }
+
+    private static void assertSource(String expected, String packageName, String label) {
+        MusicAppRegistry.App app = MusicAppRegistry.resolve(packageName, label);
+        assertEquals(expected, app.sourceId);
+        assertTrue(app.known);
+    }
+}

--- a/app/src/test/java/com/zuoqirun/lyricscompanion/MusicAppRegistryTest.java
+++ b/app/src/test/java/com/zuoqirun/lyricscompanion/MusicAppRegistryTest.java
@@ -6,6 +6,8 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
+import java.util.Arrays;
+
 public class MusicAppRegistryTest {
     @Test public void recognizesCarEditionPackageNames() {
         assertSource("qqmusic", "com.tencent.qqmusiccar", "");
@@ -35,6 +37,17 @@ public class MusicAppRegistryTest {
                 "media", "netease", "123456"));
         assertEquals("", MultiSourceLyricClient.directMediaId(
                 "netease", "qqmusic", "123456"));
+    }
+
+    @Test public void unknownPlayersDoNotHaveAHardCodedNetEasePreference() {
+        MultiSourceLyricClient.Result qq = new MultiSourceLyricClient.Result(
+                LrcTimeline.EMPTY, "QQ 音乐", "qqmusic");
+        MultiSourceLyricClient.Result netease = new MultiSourceLyricClient.Result(
+                LrcTimeline.EMPTY, "网易云音乐", "netease");
+        assertEquals("qqmusic", MultiSourceLyricClient.chooseResult(
+                "", Arrays.asList(qq, netease)).providerId);
+        assertEquals("netease", MultiSourceLyricClient.chooseResult(
+                "netease", Arrays.asList(qq, netease)).providerId);
     }
 
     private static void assertSource(String expected, String packageName, String label) {


### PR DESCRIPTION
## Summary
- recognize common QQ Music, Kugou, and Kuwo car-edition package names
- fall back to the installed application label for vendor-wrapped car players
- only trust MediaMetadata.MEDIA_ID as a direct NetEase song ID for an actual NetEase session
- remove the hard-coded NetEase fallback bias when the car system proxies all players through an unknown package
- add regression coverage for car packages, label matching, neutral fallback ordering, and Media ID isolation

## Verification
- .\\gradlew.bat :app:testDebugUnitTest :app:assembleDebug --no-daemon
- 13 unit tests passed
- Debug APK assembled successfully

## Runtime acceptance
- car-head-unit verification is still required before merging