### PR TITLE
Fix feedback inputs and listener recovery

### DIFF
--- a/app/src/main/java/com/zuoqirun/lyricscompanion/LyricsDisplayService.java
+++ b/app/src/main/java/com/zuoqirun/lyricscompanion/LyricsDisplayService.java
@@ -103,9 +103,6 @@ public final class LyricsDisplayService extends Service implements DisplayManage
         MusicStateStore.initialize(this);
         createNotificationChannel();
         startForeground(NOTIFICATION_ID, createNotification());
-        if (MusicNotificationListener.hasNotificationAccess(this)) {
-            MusicNotificationListener.requestReconnect(this);
-        }
         displayManager = (DisplayManager) getSystemService(DISPLAY_SERVICE);
         if (displayManager != null) displayManager.registerDisplayListener(this, null);
         communityHandler.post(communityHeartbeat);

--- a/app/src/main/java/com/zuoqirun/lyricscompanion/LyricsPanelView.java
+++ b/app/src/main/java/com/zuoqirun/lyricscompanion/LyricsPanelView.java
@@ -370,11 +370,14 @@ final class LyricsPanelView extends View {
         float pad = 18f * density;
         float width = getWidth();
         float height = getHeight();
-        drawPanelShadow(canvas, 24f * density, Color.argb(Math.round(opacity * 2.55f), 6, 15, 27));
-
-        paint.setColor(0x406EE7F2);
-        workRect.set(pad, 10f * density, width - pad, 13f * density);
-        canvas.drawRoundRect(workRect, 2f * density, 2f * density, paint);
+        if (opacity > 0) {
+            drawPanelShadow(canvas, 24f * density,
+                    Color.argb(Math.round(opacity * 2.55f), 6, 15, 27));
+            paint.setColor(withAlpha(0x406EE7F2,
+                    Math.round(Color.alpha(0x406EE7F2) * opacity / 100f)));
+            workRect.set(pad, 10f * density, width - pad, 13f * density);
+            canvas.drawRoundRect(workRect, 2f * density, 2f * density, paint);
+        }
 
         float usableWidth = Math.max(1f, width - pad * 2f);
         float previewShift = browseVisualOffsetPx;

--- a/app/src/main/java/com/zuoqirun/lyricscompanion/MainActivity.java
+++ b/app/src/main/java/com/zuoqirun/lyricscompanion/MainActivity.java
@@ -6,6 +6,7 @@ import android.content.ComponentName;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
+import android.content.res.ColorStateList;
 import android.graphics.Color;
 import android.graphics.drawable.GradientDrawable;
 import android.hardware.display.DisplayManager;
@@ -54,6 +55,7 @@ public final class MainActivity extends AppCompatActivity {
             "https://lyrics-companion.zuoqirun.top/versions";
     private static final ExecutorService UPDATE_EXECUTOR = Executors.newSingleThreadExecutor();
     private static final long LISTENER_HEALTH_MAX_AGE_MS = 3_000L;
+    private static final long LISTENER_INITIAL_RECONNECT_DELAY_MS = 2_500L;
     private static final long LISTENER_RECONNECT_INTERVAL_MS = 1_000L;
     private static final long LISTENER_RECONNECT_WINDOW_MS = 30_000L;
     private final Handler handler = new Handler(Looper.getMainLooper());
@@ -99,6 +101,8 @@ public final class MainActivity extends AppCompatActivity {
             if (SystemClock.elapsedRealtime() < listenerReconnectDeadlineElapsedMs) {
                 listenerReconnectScheduled = true;
                 handler.postDelayed(this, LISTENER_RECONNECT_INTERVAL_MS);
+            } else {
+                listenerReconnectScheduled = false;
             }
         }
     };
@@ -287,7 +291,7 @@ public final class MainActivity extends AppCompatActivity {
                 AppPreferences.get(this).getInt(AppPreferences.KEY_TEXT_SCALE, 100), "%",
                 value -> AppPreferences.get(this).edit()
                         .putInt(AppPreferences.KEY_TEXT_SCALE, value).apply());
-        addSeekSetting(styleCard, "背景不透明度", 45, 100,
+        addSeekSetting(styleCard, "背景不透明度", 0, 100,
                 AppPreferences.get(this).getInt(AppPreferences.KEY_OPACITY, 88), "%",
                 value -> AppPreferences.get(this).edit()
                         .putInt(AppPreferences.KEY_OPACITY, value).apply());
@@ -727,10 +731,8 @@ public final class MainActivity extends AppCompatActivity {
 
         TextInputLayout messageLayout = new TextInputLayout(this);
         messageLayout.setHint("反馈内容");
-        messageLayout.setBoxBackgroundMode(TextInputLayout.BOX_BACKGROUND_FILLED);
-        messageLayout.setBoxBackgroundColor(0xFF132238);
         TextInputEditText message = new TextInputEditText(messageLayout.getContext());
-        message.setTextColor(Color.WHITE);
+        styleFeedbackInput(messageLayout, message);
         message.setTextSize(14f);
         message.setGravity(Gravity.TOP | Gravity.START);
         message.setMinLines(4);
@@ -745,10 +747,8 @@ public final class MainActivity extends AppCompatActivity {
         TextInputLayout contactLayout = new TextInputLayout(this);
         contactLayout.setHint("联系方式（可选）");
         contactLayout.setHelperText("可填写邮箱、QQ 或 GitHub 用户名");
-        contactLayout.setBoxBackgroundMode(TextInputLayout.BOX_BACKGROUND_FILLED);
-        contactLayout.setBoxBackgroundColor(0xFF132238);
         TextInputEditText contact = new TextInputEditText(contactLayout.getContext());
-        contact.setTextColor(Color.WHITE);
+        styleFeedbackInput(contactLayout, contact);
         contact.setSingleLine(true);
         contact.setInputType(InputType.TYPE_CLASS_TEXT);
         contact.setFilters(new InputFilter[]{new InputFilter.LengthFilter(200)});
@@ -797,6 +797,17 @@ public final class MainActivity extends AppCompatActivity {
 
     private static String valueOf(TextInputEditText input) {
         return input.getText() == null ? "" : input.getText().toString().trim();
+    }
+
+    private static void styleFeedbackInput(TextInputLayout layout, TextInputEditText input) {
+        ColorStateList secondaryText = ColorStateList.valueOf(0xFF52657D);
+        layout.setBoxBackgroundMode(TextInputLayout.BOX_BACKGROUND_FILLED);
+        layout.setBoxBackgroundColor(Color.WHITE);
+        layout.setBoxStrokeColor(0xFF6EE7F2);
+        layout.setHintTextColor(secondaryText);
+        layout.setHelperTextColor(secondaryText);
+        input.setTextColor(0xFF102033);
+        input.setHintTextColor(0xFF52657D);
     }
 
     private void checkForUpdates(boolean manual) {
@@ -887,10 +898,28 @@ public final class MainActivity extends AppCompatActivity {
     }
 
     private void openNotificationAccess() {
+        if (startSettingsActivity(new Intent("android.settings.ACTION_NOTIFICATION_LISTENER_SETTINGS"))) {
+            return;
+        }
+        // Notification access exists on Android 4.4, but its public settings action was only
+        // added in API 22. AOSP KitKat exposes this activity; vendor ROMs may not, so keep
+        // every fallback resolve-checked.
+        Intent kitKatNotificationAccess = new Intent().setComponent(new ComponentName(
+                "com.android.settings", "com.android.settings.Settings$NotificationAccessSettingsActivity"));
+        if (startSettingsActivity(kitKatNotificationAccess)) return;
+        if (startSettingsActivity(new Intent(Settings.ACTION_SECURITY_SETTINGS))) return;
+        if (startSettingsActivity(new Intent(Settings.ACTION_SETTINGS))) return;
+        Toast.makeText(this, "\u65e0\u6cd5\u6253\u5f00\u7cfb\u7edf\u7684\u901a\u77e5\u8bfb\u53d6\u8bbe\u7f6e\uff0c\u8bf7\u5728\u7cfb\u7edf\u8bbe\u7f6e\u4e2d\u624b\u52a8\u5f00\u542f\u3002",
+                Toast.LENGTH_LONG).show();
+    }
+
+    private boolean startSettingsActivity(Intent intent) {
         try {
-            startActivity(new Intent("android.settings.ACTION_NOTIFICATION_LISTENER_SETTINGS"));
+            if (intent.resolveActivity(getPackageManager()) == null) return false;
+            startActivity(intent);
+            return true;
         } catch (Throwable ignored) {
-            startActivity(new Intent(Settings.ACTION_SECURITY_SETTINGS));
+            return false;
         }
     }
 
@@ -902,7 +931,9 @@ public final class MainActivity extends AppCompatActivity {
         listenerReconnectDeadlineElapsedMs = SystemClock.elapsedRealtime()
                 + LISTENER_RECONNECT_WINDOW_MS;
         listenerReconnectScheduled = true;
-        listenerReconnect.run();
+        // Let NotificationManager restore its listener first. Requesting a rebind immediately
+        // after returning from Settings can race the platform's natural bind on Android 7+.
+        handler.postDelayed(listenerReconnect, LISTENER_INITIAL_RECONNECT_DELAY_MS);
     }
 
     private String listenerState(boolean notificationAccess) {

--- a/app/src/main/java/com/zuoqirun/lyricscompanion/MusicNotificationListener.java
+++ b/app/src/main/java/com/zuoqirun/lyricscompanion/MusicNotificationListener.java
@@ -22,7 +22,11 @@ public final class MusicNotificationListener extends NotificationListenerService
     private static final long SESSION_POLL_MS = 600L;
     private static final long EMPTY_SESSION_GRACE_MS = 5_000L;
     private static final long LEGACY_NATURAL_REBIND_GRACE_MS = 2_500L;
+    private static final long LEGACY_REBIND_DISABLE_MS = 750L;
+    private static final long COMPONENT_RECOVERY_DELAY_MS = 6_000L;
+    private static final long COMPONENT_RECOVERY_COOLDOWN_MS = 15_000L;
     private static final long PROCESS_CLASS_LOADED_ELAPSED_MS = SystemClock.elapsedRealtime();
+    private static final Handler REBIND_HANDLER = new Handler(Looper.getMainLooper());
     private final Handler handler = new Handler(Looper.getMainLooper());
     private MusicSessionReader sessionReader;
     private LegacyRemoteControllerReader legacyReader;
@@ -35,12 +39,16 @@ public final class MusicNotificationListener extends NotificationListenerService
     private static volatile String lastSessionError = "";
     private static volatile String backendName = "";
     private static volatile long lastReconnectRequestElapsedMs;
+    private static volatile long reconnectStartedElapsedMs;
+    private static volatile long lastComponentRecoveryElapsedMs;
+    private static volatile boolean legacyRebindInProgress;
 
     private final MusicSessionReader.Callback readerCallback = new MusicSessionReader.Callback() {
         @Override public void onReadSuccess(int sessionCount) {
             lastSuccessfulSessionReadElapsedMs = SystemClock.elapsedRealtime();
             lastSessionCount = Math.max(0, sessionCount);
             lastSessionError = "";
+            reconnectStartedElapsedMs = 0L;
         }
 
         @Override public void onReadError(String message, Throwable error) {
@@ -81,6 +89,14 @@ public final class MusicNotificationListener extends NotificationListenerService
             }
         }
     };
+    private final Runnable reconnectAfterSystemDisconnect = new Runnable() {
+        @Override public void run() {
+            if (Build.VERSION.SDK_INT >= 24 && !connected
+                    && hasNotificationAccess(MusicNotificationListener.this)) {
+                requestReconnect(MusicNotificationListener.this);
+            }
+        }
+    };
 
     @Override public void onCreate() {
         super.onCreate();
@@ -96,6 +112,7 @@ public final class MusicNotificationListener extends NotificationListenerService
 
     @Override public void onListenerConnected() {
         if (Build.VERSION.SDK_INT < 21) return;
+        handler.removeCallbacks(reconnectAfterSystemDisconnect);
         startListening();
     }
 
@@ -131,6 +148,11 @@ public final class MusicNotificationListener extends NotificationListenerService
 
     @Override public void onListenerDisconnected() {
         stopListening();
+        // API 24+ tells us that the system side has disconnected. Retry from this lifecycle
+        // callback instead of racing the initial bind when the permission screen closes.
+        if (Build.VERSION.SDK_INT >= 24 && hasNotificationAccess(this)) {
+            handler.postDelayed(reconnectAfterSystemDisconnect, 500L);
+        }
     }
 
     @Override public void onNotificationPosted(StatusBarNotification sbn) {
@@ -177,6 +199,7 @@ public final class MusicNotificationListener extends NotificationListenerService
     }
 
     @Override public void onDestroy() {
+        handler.removeCallbacks(reconnectAfterSystemDisconnect);
         stopListening();
         super.onDestroy();
     }
@@ -284,33 +307,83 @@ public final class MusicNotificationListener extends NotificationListenerService
     }
 
     static void requestReconnect(Context context) {
-        if (context == null || !hasNotificationAccess(context) || isHealthy(3_000L)) return;
+        if (context == null || !hasNotificationAccess(context)) return;
+        if (isHealthy(3_000L)) {
+            reconnectStartedElapsedMs = 0L;
+            return;
+        }
         long now = SystemClock.elapsedRealtime();
+        if (reconnectStartedElapsedMs <= 0L) reconnectStartedElapsedMs = now;
         if (Build.VERSION.SDK_INT < 24
                 && now - PROCESS_CLASS_LOADED_ELAPSED_MS < LEGACY_NATURAL_REBIND_GRACE_MS) {
             return;
         }
         if (now - lastReconnectRequestElapsedMs < 2_000L) return;
         lastReconnectRequestElapsedMs = now;
-        ComponentName component = new ComponentName(context, MusicNotificationListener.class);
+        Context appContext = context.getApplicationContext();
+        ComponentName component = new ComponentName(appContext, MusicNotificationListener.class);
         try {
             if (Build.VERSION.SDK_INT >= 24) {
-                Api24.requestRebind(component);
+                boolean shouldRecoverComponent = now - reconnectStartedElapsedMs
+                        >= COMPONENT_RECOVERY_DELAY_MS
+                        && (lastComponentRecoveryElapsedMs <= 0L
+                        || now - lastComponentRecoveryElapsedMs >= COMPONENT_RECOVERY_COOLDOWN_MS);
+                if (shouldRecoverComponent) {
+                    lastComponentRecoveryElapsedMs = now;
+                    lastSessionError = "\u7cfb\u7edf\u76d1\u542c\u5668\u672a\u7ed1\u5b9a\uff0c\u6b63\u5728\u91cd\u542f\u76d1\u542c\u7ec4\u4ef6";
+                    requestLegacyRebind(appContext, component);
+                } else {
+                    Api24.requestRebind(component);
+                }
             } else {
-                // requestRebind() was added in API 24. Toggling this exact service component
-                // makes NotificationManager re-evaluate enabled listeners on Android 4.4-6.0.
-                PackageManager manager = context.getPackageManager();
-                manager.setComponentEnabledSetting(component,
-                        PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
-                        PackageManager.DONT_KILL_APP);
-                manager.setComponentEnabledSetting(component,
-                        PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
-                        PackageManager.DONT_KILL_APP);
+                requestLegacyRebind(appContext, component);
             }
         } catch (Throwable error) {
             lastSessionError = "请求重连失败: " + safeMessage(error);
             Log.w(TAG, "Unable to request notification-listener rebind", error);
         }
+    }
+
+    /**
+     * Android 4.4-6.0 has no NotificationListenerService.requestRebind(). A back-to-back
+     * disable/enable call is commonly coalesced by the package manager, leaving the access entry
+     * present in Settings but without a live listener after the app process is recreated. Keep
+     * the component disabled briefly so NotificationManager observes both transitions.
+     */
+    private static void requestLegacyRebind(Context context, ComponentName component) {
+        if (legacyRebindInProgress) return;
+        legacyRebindInProgress = true;
+        PackageManager manager = context.getPackageManager();
+        try {
+            manager.setComponentEnabledSetting(component,
+                    PackageManager.COMPONENT_ENABLED_STATE_DISABLED,
+                    PackageManager.DONT_KILL_APP);
+        } catch (Throwable error) {
+            legacyRebindInProgress = false;
+            throw error;
+        }
+        REBIND_HANDLER.postDelayed(() -> {
+            try {
+                manager.setComponentEnabledSetting(component,
+                        PackageManager.COMPONENT_ENABLED_STATE_ENABLED,
+                        PackageManager.DONT_KILL_APP);
+            } catch (Throwable error) {
+                lastSessionError = "Unable to re-enable notification listener: "
+                        + safeMessage(error);
+                Log.w(TAG, "Unable to re-enable notification listener", error);
+            } finally {
+                legacyRebindInProgress = false;
+            }
+            if (Build.VERSION.SDK_INT >= 24 && hasNotificationAccess(context)) {
+                try {
+                    Api24.requestRebind(component);
+                } catch (Throwable error) {
+                    lastSessionError = "Unable to rebind notification listener: "
+                            + safeMessage(error);
+                    Log.w(TAG, "Unable to rebind notification listener", error);
+                }
+            }
+        }, LEGACY_REBIND_DISABLE_MS);
     }
 
     static boolean shouldClearAfterEmpty(long lastNonEmptyElapsedMs, long nowElapsedMs) {


### PR DESCRIPTION
## What changed
- Restyled both feedback dialog inputs with a white background, dark text, and visible hint/helper colors.
- Allowed a fully transparent lyric panel background.
- Hardened notification-listener recovery on Android 7+ and safe settings navigation on Android 4.4.

## Why
The feedback fields did not match the intended white input treatment. Users also reported notification access remaining granted while the listener never rebound after reopening the app, plus a KitKat crash when opening notification access.

## Validation
- Inspected the complete diff and ran `git diff --check`.
- Gradle and device tests were intentionally not run; runtime testing is user-gated.